### PR TITLE
Rolled in upstream fix for mongodb arbiter. make db creds persistent …

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ helm install gostint/ --name aut-op
 ```
 This starts etcd, vault, mongodb and gostint services.
 
-Init the vault:
+Wait for Vault PODs to be in running state then Init the vault:
 ```bash
 gostint/init/vault-init.sh aut-op default
 ```
@@ -77,7 +77,7 @@ e.g.:
 Service | Ingress URL
 ------- | -----------
 vault   | https://url/vault
-gostint   | https://url/gostint
+gostint | https://url/gostint
 
 So an execution of `gostint-client` could look like:
 ```bash
@@ -97,3 +97,7 @@ gostint-client \
 Init Ingress:
 ```bash
 gostint/init/ingress-init.sh aut-op default
+
+IMPORTANT: The above path based ingress for vault breaks end-to-end TLS
+encryption and could present a security risk.  SSL Pasthrough with SNI
+hostname based routing may be a better option...

--- a/gostint/Chart.yaml
+++ b/gostint/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.9"
 description: GoStint Secure DevOps Automation
 name: gostint
-version: 2.0.0
+version: 2.1.0

--- a/gostint/charts/mongodb/templates/pre-install-secrets.yaml
+++ b/gostint/charts/mongodb/templates/pre-install-secrets.yaml
@@ -1,4 +1,4 @@
-{{ if and .Values.usePassword (not .Values.existingSecret) -}}
+{{ if or .Values.usePassword .Values.mongodbPassword -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,6 +8,13 @@ metadata:
     chart: {{ template "mongodb.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+
+    "app.kubernetes.io/managed-by": {{ .Release.Service | quote}}
+    "app.kubernetes.io/instance": {{ .Release.Name | quote}}
+    "helm.sh/chart": {{ .Chart.Name }}-{{ .Chart.Version }}
+  annotations:
+    "helm.sh/hook": pre-install
+    # "helm.sh/hook-delete-policy": before-hook-creation  # delete for reinstall
 type: Opaque
 data:
   {{- if .Values.usePassword }}

--- a/gostint/charts/mongodb/templates/statefulset-arbiter-rs.yaml
+++ b/gostint/charts/mongodb/templates/statefulset-arbiter-rs.yaml
@@ -78,11 +78,13 @@ spec:
             value: {{ default "" .Values.mongodbExtraFlags | join " " }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
-            exec:
-              command:
-                - mongo
-                - --eval
-                - "db.adminCommand('ping')"
+            # exec:
+            #   command:
+            #     - mongo
+            #     - --eval
+            #     - "db.adminCommand('ping')"
+            tcpSocket:
+              port: mongodb
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
@@ -91,11 +93,13 @@ spec:
           {{- end }}
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
-            exec:
-              command:
-                - mongo
-                - --eval
-                - "db.adminCommand('ping')"
+            # exec:
+            #   command:
+            #     - mongo
+            #     - --eval
+            #     - "db.adminCommand('ping')"
+            tcpSocket:
+              port: mongodb
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}


### PR DESCRIPTION
…in helm pre-install to support pod replacement causing loss of creds secrets.