### PR TITLE
bump chart to 2.3.0. gostint to v1.1.1. added support for draining a …

### DIFF
--- a/gostint/Chart.yaml
+++ b/gostint/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.9"
 description: GoStint Secure DevOps Automation
 name: gostint
-version: 2.2.0
+version: 2.3.0

--- a/gostint/templates/deployment.yaml
+++ b/gostint/templates/deployment.yaml
@@ -72,6 +72,7 @@ spec:
               done
               exit 1
               # ) >> /init.log 2>&1
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -80,6 +81,29 @@ spec:
             - name: https
               containerPort: 3232
               protocol: TCP
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - 'sh'
+                  - '-x'
+                  - '-c'
+                  - |-
+                    # (
+                    GPID=$(ps -e | grep /usr/bin/gostint | grep -v grep | awk '{print $1;}')
+                    kill -INT $GPID
+                    sleep 5
+                    while [ 1 == 1 ]
+                    do
+                      running_jobs=$(curl -s -k https://127.0.0.1:3232/v1/api/health?k=running_jobs)
+                      if [ "$running_jobs" == "0" ]
+                      then
+                        kill $GPID
+                        exit 0
+                      fi
+                      sleep 5
+                    done
+                    # ) >> /tmp/stop.log 2>&1
           livenessProbe:
             exec:
               command:

--- a/gostint/values.yaml
+++ b/gostint/values.yaml
@@ -10,7 +10,7 @@ replicaCount: 3
 
 image:
   repository: goethite/gostint
-  tag: v1.0.1
+  tag: v1.1.1
   pullPolicy: IfNotPresent
   # pullPolicy: Always
 
@@ -55,6 +55,10 @@ tolerations: []
 
 affinity: {}
 
+terminationGracePeriodSeconds: 600
+
+# IMPORTANT: If you upgrade the vault, then you will need to rerun the unseal
+# script, as each new pod will always start in a sealed state.
 vault:
   baseImage: goethite/gostint-vault
   version: "0.11.3"


### PR DESCRIPTION
…terminating node (with configurable 10 minute cutoff) to prevent killing mid running job.