### PR TITLE
fixed mongodb chart for deploying to microk8s. Enabled gostint ui by …

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,16 @@ https://goethite.github.io/gostint/
 
 This is a proof-of-concept helm chart for the GoStint project.
 
-This is a work in progress and not for production use...
+This is a work in progress and __not for production use...__
+
+The goal is to provide a pre-packaged demo environment for GoStint, with
+Hashicorp Vault etc all preconfigured.
+
+The PoC GoStint UI is enabled by default in the helm chart and can be accessed
+by pointing your browser at https://your-k8s-ingess/gostint.
+The `values.yaml` setting `ui.vaultExternalAddr` must be set to the ingress
+url of the Vault, e.g. https://your-k8s-ingress/vault (see also comments
+below regarding the Ingress Controller).
 
 ## IMPORTANT v1 -> v2
 The upgrade of the helm chart fro v1.* to v2.* is a breaking change due to
@@ -56,7 +65,7 @@ Unseal the vault:
 ```bash
 gostint/init/vault-unseal.sh aut-op default
 ```
-WARNING: This approach for initialising and unsealing the vault is probably
+WARNING: This approach for initialising and unsealing the vault is
 not suitable for Production use - see the Vault Docs.
 
 Init GoStint:
@@ -64,11 +73,6 @@ Init GoStint:
 gostint/init/gostint-init.sh aut-op default
 ```
 NOTE: the gostint pods will wait for this init step to be completed.
-
-### Upgrade GoStint
-```bash
-helm upgrade aut-op gostint/
-```
 
 ### Ingress Controller
 The helm chart also deploys an Ingress Controller on port 443 to allow a single
@@ -98,9 +102,14 @@ gostint-client \
 Init Ingress:
 ```bash
 gostint/init/ingress-init.sh aut-op default
+```
 
 IMPORTANT: The above path based ingress for vault breaks end-to-end TLS
 encryption and could present a security risk (for gostint-client authenticating,
 but not for the actual submission of the job).  SSL Pasthrough with SNI
-hostname based routing may be a better option, or better yet, direct access to
-the vault.
+hostname based routing may be a better option.
+
+### Upgrade GoStint
+```bash
+helm upgrade aut-op gostint/
+```

--- a/gostint/Chart.yaml
+++ b/gostint/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.2"
 description: GoStint Secure DevOps Automation
 name: gostint
-version: 2.7.0
+version: 2.8.0

--- a/gostint/charts/mongodb/templates/statefulset-primary-rs.yaml
+++ b/gostint/charts/mongodb/templates/statefulset-primary-rs.yaml
@@ -61,9 +61,11 @@ spec:
             value: "$(MONGODB_POD_NAME).{{ template "mongodb.fullname" . }}-headless.{{ .Release.Namespace }}"
             {{- end }}
           - name: MONGODB_USERNAME
-            value: {{ .Values.mongodbUsername | quote }}
+            # value: {{ .Values.mongodbUsername | quote }}
+            value: {{ default "" .Values.mongodbUsername | quote }}
           - name: MONGODB_DATABASE
-            value: {{ .Values.mongodbDatabase | quote }}
+            # value: {{ .Values.mongodbDatabase | quote }}
+            value: {{ default "" .Values.mongodbDatabase | quote }}
             {{- if .Values.usePassword }}
             {{- if .Values.mongodbPassword }}
           - name: MONGODB_PASSWORD

--- a/gostint/templates/deployment.yaml
+++ b/gostint/templates/deployment.yaml
@@ -156,6 +156,16 @@ spec:
               value: /gostint-tls/cert.pem
             - name: GOSTINT_SSL_KEY
               value: /gostint-tls/key.pem
+            - name: GOSTINT_UI
+              {{- if .Values.ui.enabled }}
+              value: "1"
+              {{- else }}
+              value: "0"
+              {{- end }}
+            {{- if .Values.ui.vaultExternalAddr }}
+            - name: VAULT_EXTERNAL_ADDR
+              value: {{ .Values.ui.vaultExternalAddr | quote }}
+            {{- end }}
           volumeMounts:
             - name: tls
               mountPath: "/gostint-tls"

--- a/gostint/templates/ingress-deployment.yaml
+++ b/gostint/templates/ingress-deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     {{ $key }}: {{ $value | quote }}
     {{- end }}
     nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/add-base-url: "true"
     # ingress.kubernetes.io/ssl-passthrough: "true"
     # nginx.ingress.kubernetes.io/secure-backends: "true"
   name: {{ template "gostint.fullname" . }}-ingress-gostint

--- a/gostint/values.yaml
+++ b/gostint/values.yaml
@@ -10,7 +10,7 @@ replicaCount: 3
 
 image:
   repository: goethite/gostint
-  tag: v1.4.0
+  tag: v1.6.5
   pullPolicy: IfNotPresent
   # pullPolicy: Always
 
@@ -40,6 +40,12 @@ ingress:
 # Experimental SNI Ingress
 sniIngress:
   enabled: false
+
+ui:
+  enabled: true
+
+  # The external ingress url that the UI will see from the browser
+  vaultExternalAddr: "https://192.168.0.62/vault"
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
…default and provide means to set the vault's external ingress url. add-base-url to set base href for ingress path.