### PR TITLE
bump chart version to 3.0.0 due to migration from etcd to consul back…

### DIFF
--- a/gostint/Chart.yaml
+++ b/gostint/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 appVersion: "1.6"
-description: GoStint Secure DevOps Automation
+description: GoStint for Secure Containered DevOps Automation
 name: gostint
-version: 2.9.0
+version: 3.0.0


### PR DESCRIPTION
…end for vault.